### PR TITLE
Fix bug in retrieving `replacer` option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var createPreprocessor = function(args, config, logger, helper) {
 
   var options = helper.merge(defaultOptions, args.options || {}, config.options || {});
 
-  var replacer = args.replacer || config.replacer || function(file, content) {
+  var replacer = options.replacer || config.replacer || function(file, content) {
     return content;
   };
 


### PR DESCRIPTION
This fixes a bug in retrieving `replacer`. In my usage I'm defining a custom preprocessor and `replacer` is provided via `args.options.replacer`.